### PR TITLE
Provide datasource connection info via code

### DIFF
--- a/aoe-infra/infra/environments/dev.json
+++ b/aoe-infra/infra/environments/dev.json
@@ -10,7 +10,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-97",
+            "image_tag": "ga-105",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOGGING_LEVEL_FI_CSC": "ERROR",
@@ -21,14 +21,11 @@
                 "SPRING_PROFILES_ACTIVE": "prod",
                 "SPRING_AUTOCONFIGURATION_EXCLUDE": "org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration",
 
-                "SPRING_DATASOURCE_PRIMARY_URL": "jdbc:postgresql://dev-web-backend-aurora-devwebbackendwriter4c162db7-zjabck717tnp.clykem0ww4fy.eu-west-1.rds.amazonaws.com:5432/aoe",
                 "SPRING_DATASOURCE_PRIMARY_USERNAME": "reporter",
                 "SPRING_DATASOURCE_PRIMARY_INITIALIZATIONMODE": "never",
                 "SPRING_DATASOURCE_PRIMARY_DRIVERCLASSNAME": "org.postgresql.Driver",
 
                 "MONGODB_PRIMARY_ENABLE_SSL": "true",
-                "MONGODB_PRIMARY_HOST": "aoedocumentdb624326a2-4ass18z7c2f2.cluster-clykem0ww4fy.eu-west-1.docdb.amazonaws.com",
-                "MONGODB_PRIMARY_PORT": "27017",
                 "MONGODB_PRIMARY_DATABASE": "analytics",
                 "MONGODB_PRIMARY_USERNAME": "aoeOwner",
 
@@ -37,12 +34,10 @@
                 "TRUST_STORE_LOCATION": "/certs/rds-truststore.jks",
 
                 "SPRING_KAFKA_CONSUMER_AUTO_STARTUP": "true",
-                "SPRING_KAFKA_CONSUMER_BOOTSTRAPSERVERS": "b-2.aoekafkacluster.ofj9dw.c2.kafka.eu-west-1.amazonaws.com:9098,b-1.aoekafkacluster.ofj9dw.c2.kafka.eu-west-1.amazonaws.com:9098",
                 "SPRING_KAFKA_CONSUMER_AUTOOFFSETRESET": "latest",
                 "SPRING_KAFKA_CONSUMER_ENABLEAUTOCOMMIT": "true",
                 "SPRING_KAFKA_PRODUCER_BATCH_SIZE": "10",
                 "SPRING_KAFKA_PRODUCER_CLIENTID": "aoe-kafka-client",
-                "SPRING_KAFKA_PRODUCER_BOOTSTRAPSERVERS": "b-2.aoekafkacluster.ofj9dw.c2.kafka.eu-west-1.amazonaws.com:9098,b-1.aoekafkacluster.ofj9dw.c2.kafka.eu-west-1.amazonaws.com:9098",
 
                 "KAFKA_GROUPID_PRODMATERIALACTIVITY": "group-prod-material-activity",
                 "KAFKA_GROUPID_PRODSEARCHREQUESTS": "group-prod-search-requests",
@@ -56,7 +51,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-47",
+            "image_tag": "ga-105",
             "allow_ecs_exec": true,
             "env_vars": {
                 "SPRING_PROFILES_ACTIVE": "prod",
@@ -71,7 +66,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-98",
+            "image_tag": "ga-105",
             "allow_ecs_exec": true,
             "env_vars": {
                 "PROXY_URI":  "http://localhost",
@@ -86,13 +81,10 @@
                 "HTTP_OPTIONS_RETRY": "2",
                 "HTTP_OPTIONS_CLOCK_TOLERANCE":"5",
 
-                "POSTGRESQL_HOST": "dev-web-backend-aurora-devwebbackendwriter4c162db7-zjabck717tnp.clykem0ww4fy.eu-west-1.rds.amazonaws.com",
-                "POSTGRESQL_PORT": "5432",
                 "POSTGRESQL_DATA": "aoe",
                 "PG_USER": "aoe_admin",
                 "SERVER_CONFIG_OAIPMH_ANALYTICS_URL": "https://dev.aoe.fi:8080/oaipmh",
                 "KAFKA_EXCLUDED_AGENT_IDENTIFIERS": "oersi",
-                "KAFKA_BROKER_SERVERS": "b-2.aoekafkacluster.ofj9dw.c2.kafka.eu-west-1.amazonaws.com:9098,b-1.aoekafkacluster.ofj9dw.c2.kafka.eu-west-1.amazonaws.com:9098",
                 "KAFKA_BROKER_TOPIC_MATERIAL_ACTIVITY": "prod_material_activity",
                 "KAFKA_BROKER_TOPIC_SEARCH_REQUESTS": "prod_search_requests",
                 "KAFKA_CLIENT_ID": "aoe-web-backend",
@@ -123,7 +115,6 @@
                 "FAILURE_REDIRECT_URI": "/api/login",
 
                 "CREATE_ES_INDEX": "1",
-                "ES_NODE": "https://q424y19mb1m0b1alqi09.eu-west-1.aoss.amazonaws.com",
                 "ES_INDEX": "aoe",
                 "ES_MAPPING_FILE": "/app/aoemapping.json",
                 "ES_COLLECTION_INDEX": "aoecollection",
@@ -152,8 +143,6 @@
                 "THUMBNAIL_DOWNLOAD_URL": "https://dev.aoe.fi/api/v1/thumbnail/",
                 "COLLECTION_THUMBNAIL_DOWNLOAD_URL": "https://dev.aoe.fi/api/v1/collection/thumbnail/",
 
-                "REDIS_HOST": "semantic-apis-cdb80h.serverless.euw1.cache.amazonaws.com",
-                "REDIS_PORT": "6379",
                 "REDIS_USERNAME": "app",
                 "REDIS_USE_TLS": "true",
                 "BASE_URL": "https://dev.aoe.fi/api/v1/",
@@ -183,7 +172,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-47",
+            "image_tag": "ga-105",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOG_LEVEL": "error",
@@ -199,13 +188,11 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-25",
+            "image_tag": "ga-105",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOG_LEVEL": "debug",
                 "PORT_LISTEN": "8080",
-                "REDIS_HOST": "semantic-apis-cdb80h.serverless.euw1.cache.amazonaws.com",
-                "REDIS_PORT": "6379",
                 "REDIS_USERNAME": "app",
                 "REDIS_EXPIRE_TIME": "86400",
                 "REDIS_USE_TLS": "true",
@@ -237,16 +224,17 @@
             "version": "16.4",
             "min_size_acu": 0.5,
             "max_size_acu": 1,
-            "performance_insights": false,
-            "domain_names": ["data-analytics"]
+            "performance_insights": false
           },
           "web_backend": {
             "version": "16.4",
             "min_size_acu": 0.5,
             "max_size_acu": 1,
-            "performance_insights": false,
-            "domain_names": ["web-backend"]
+            "performance_insights": false
           }
+    },
+    "document_db": {
+        "engineVersion": "4.0.0"
     },
     "S3": {
         "aoeBucketName": "aoe",

--- a/aoe-infra/infra/lib/bastion-stack.ts
+++ b/aoe-infra/infra/lib/bastion-stack.ts
@@ -39,6 +39,7 @@ export class BastionStack extends Stack {
           'aoss:DescribeIndex',
           'aoss:ReadDocument',
           'aoss:WriteDocument',
+          'kafka:GetBootstrapBrokers',
         ],
         resources: ['*']
       })
@@ -69,7 +70,6 @@ export class BastionStack extends Stack {
 
       const userDataScript = readFileSync('./scripts/bastion_userdata.sh', 'utf8');
 
-//      bastionHost.instance.addUserData('yum install -y mariadb105 mongodb-mongosh-shared-openssl3 mongodb-database-tools postgresql15 redis7 htop python3-pip python3-wheel jq bash tmux nohup');
       bastionHost.instance.addUserData(userDataScript);
       bastionHost.role.addToPrincipalPolicy(allowSessionManager)
       bastionHost.role.addToPrincipalPolicy(allowKmsDecrypt(props.kmsKey.keyArn))

--- a/aoe-infra/infra/lib/msk-stack.ts
+++ b/aoe-infra/infra/lib/msk-stack.ts
@@ -3,6 +3,10 @@ import { Construct } from "constructs";
 import { IVpc, SecurityGroup } from "aws-cdk-lib/aws-ec2";
 import * as msk from "aws-cdk-lib/aws-msk";
 import { Key } from "aws-cdk-lib/aws-kms";
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as cr from 'aws-cdk-lib/custom-resources';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Duration } from "aws-cdk-lib";
 
 interface MskStackProps extends cdk.StackProps {
   volumeSize: number;
@@ -18,7 +22,8 @@ interface MskStackProps extends cdk.StackProps {
 
 export class MskStack extends cdk.Stack {
 
-  public kafkaCluster: msk.CfnCluster;
+  public readonly kafkaCluster: msk.CfnCluster;
+  public readonly bootstrapBrokers: string;
 
   constructor(scope: Construct, id: string, props: MskStackProps) {
     super(scope, id, props);
@@ -54,6 +59,61 @@ export class MskStack extends cdk.Stack {
           dataVolumeKmsKeyId: props.kmsKey.keyId,
         },
       },
+    });
+
+    const getBootstrapBrokersLambda = new lambda.Function(this, 'GetBootstrapBrokersLambda', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline(`
+        exports.handler = async (event) => {
+          const { KafkaClient, GetBootstrapBrokersCommand } = require("@aws-sdk/client-kafka"); // CommonJS import
+          const client = new KafkaClient();
+          const clusterArn = event.ResourceProperties.ClusterArn;
+        
+          if (event.RequestType === 'Delete') {
+            return { PhysicalResourceId: clusterArn };
+          }
+        
+          try {
+            const command = new GetBootstrapBrokersCommand({ ClusterArn: clusterArn });
+            const response = await client.send(command);
+     
+            return {
+              PhysicalResourceId: clusterArn,
+              Data: {
+                BootstrapBrokerStringSaslIam: response.BootstrapBrokerStringSaslIam,
+              },
+            };
+          } catch (error) {
+            console.error(error);
+            throw new Error('Failed to retrieve bootstrap brokers: ' + error.message);
+          }
+        };
+      `),
+      timeout: Duration.minutes(2),
+      initialPolicy: [
+        new iam.PolicyStatement({
+          actions: ['kafka:GetBootstrapBrokers'],
+          resources: [this.kafkaCluster.attrArn],
+        }),
+      ],
+    });
+
+    const customResourceProvider = new cr.Provider(this, 'CustomResourceProvider', {
+      onEventHandler: getBootstrapBrokersLambda,
+    });
+
+    const bootstrapBrokersResource = new cdk.CustomResource(this, 'BootstrapBrokersResource', {
+      serviceToken: customResourceProvider.serviceToken,
+      properties: {
+        ClusterArn: this.kafkaCluster.attrArn,
+      },
+    });
+
+    this.bootstrapBrokers = bootstrapBrokersResource.getAttString('BootstrapBrokerStringSaslIam')
+
+    new cdk.CfnOutput(this, 'BootstrapServers', {
+      value: this.bootstrapBrokers,
     });
 
   }

--- a/aoe-infra/infra/lib/opensearch-stack.ts
+++ b/aoe-infra/infra/lib/opensearch-stack.ts
@@ -9,11 +9,12 @@ interface OpenSearchServerlessStackProps extends cdk.StackProps {
     vpc: ec2.IVpc;
     securityGroupIds: string[];
     kmsKey: Key;
-    standbyReplicas: 'DISABLED' | 'ENABLED'
+    standbyReplicas: 'DISABLED' | 'ENABLED',
 }
 
 export class OpenSearchServerlessStack extends cdk.Stack {
-    readonly collectionArn: string
+    public readonly collectionArn: string
+    public readonly collectionEndpoint: string;
     constructor(scope: cdk.App, id: string, props: OpenSearchServerlessStackProps) {
         super(scope, id, props);
 
@@ -92,12 +93,12 @@ export class OpenSearchServerlessStack extends cdk.Stack {
 
         })
 
-
         collection.addDependency(encryptionPolicy);
         collection.addDependency(networkPolicy);
         collection.addDependency(dataAccessPolicy);
 
         this.collectionArn = collection.attrArn
+        this.collectionEndpoint = collection.attrCollectionEndpoint
 
         new cdk.CfnOutput(this, 'CollectionArn', {
             value: collection.attrArn,

--- a/aoe-infra/infra/lib/redis-stack.ts
+++ b/aoe-infra/infra/lib/redis-stack.ts
@@ -1,4 +1,3 @@
-
 import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 import { aws_elasticache as ElastiCache } from "aws-cdk-lib";
@@ -7,72 +6,75 @@ import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 import { IKey } from "aws-cdk-lib/aws-kms";
 
 interface ElastiCacheServerlessStackProps extends cdk.StackProps {
-    vpc: ec2.IVpc;
-    elasticacheName: string;
-    secret: secretsmanager.Secret;
-    consumingServiceName: string;
-    redisKmsKeyId: string;
-    secretsManagerKmsKeyId: IKey;
-    securityGroupId: string;
-    redisMajorVersion: string;
-    storageMin: number;
-    storageMax: number;
-    minEcpuPerSecond: number;
-    maxEcpuPerSecond: number;
+  vpc: ec2.IVpc;
+  elasticacheName: string;
+  secret: secretsmanager.Secret;
+  consumingServiceName: string;
+  redisKmsKeyId: string;
+  secretsManagerKmsKeyId: IKey;
+  securityGroupId: string;
+  redisMajorVersion: string;
+  storageMin: number;
+  storageMax: number;
+  minEcpuPerSecond: number;
+  maxEcpuPerSecond: number;
 }
 
 export class ElasticacheServerlessStack extends cdk.Stack {
-    constructor(scope: Construct, id: string, props: ElastiCacheServerlessStackProps) {
-      super(scope, id, props);
+  public readonly endpointAddress: string;
+  public readonly endpointPort: string;
+  constructor(scope: Construct, id: string, props: ElastiCacheServerlessStackProps) {
+    super(scope, id, props);
 
-        const redisUserName = "app"
+    const redisUserName = "app"
 
+    const cfnUser = new ElastiCache.CfnUser(this, 'MyCfnUser', {
+      engine: "redis",
+      userId: redisUserName,
+      userName: redisUserName,
+      noPasswordRequired: false,
+      passwords: [ props.secret.secretValueFromJson('secretkey').unsafeUnwrap() ],
+      accessString: "on ~* +@all",
+    });
 
-        const cfnUser = new ElastiCache.CfnUser(this, 'MyCfnUser', {
-            engine: "redis",
-            userId: redisUserName,
-            userName: redisUserName,
-            noPasswordRequired: false,
-            passwords: [props.secret.secretValueFromJson('secretkey').unsafeUnwrap()],
-            accessString: "on ~* +@all",
-        });
+    const cfnUserGroup = new ElastiCache.CfnUserGroup(this, 'MyCfnUserGroup', {
+      engine: 'redis',
+      userGroupId: `${props.elasticacheName}-userGroupId`.toLowerCase(),
+      userIds: [ cfnUser.userId, "default" ],
+    });
 
-        const cfnUserGroup = new ElastiCache.CfnUserGroup(this, 'MyCfnUserGroup', {
-            engine: 'redis',
-            userGroupId: `${props.elasticacheName}-userGroupId`.toLowerCase(),
-            userIds: [cfnUser.userId, "default"],
-        });
+    cfnUserGroup.node.addDependency(cfnUser);
 
-        cfnUserGroup.node.addDependency(cfnUser);
-
-        const elastiCacheSubnetIds  : string[] = [];
-        for (const subnet of props.vpc.isolatedSubnets) {
-        elastiCacheSubnetIds.push(subnet.subnetId);
-        }
-
-
-        const elastiCacheServlerless = new ElastiCache.CfnServerlessCache(this, "ServerlessCache", {
-                engine: "redis",
-                serverlessCacheName: props.elasticacheName.toLowerCase(),
-                cacheUsageLimits: {
-                    dataStorage: {
-                    unit: "GB",
-
-                    maximum: props.storageMax,
-                    minimum: props.storageMin,
-                    },
-                    ecpuPerSecond: {
-                    maximum: props.maxEcpuPerSecond,
-                    minimum: props.minEcpuPerSecond,
-                    },
-                },
-                kmsKeyId: props.redisKmsKeyId,
-                majorEngineVersion: props.redisMajorVersion,
-                securityGroupIds: [props.securityGroupId],
-                subnetIds: elastiCacheSubnetIds,
-                userGroupId: `${props.elasticacheName}-userGroupId`.toLowerCase(),
-            });
-
-        elastiCacheServlerless.node.addDependency(cfnUserGroup)
+    const elastiCacheSubnetIds: string[] = [];
+    for (const subnet of props.vpc.isolatedSubnets) {
+      elastiCacheSubnetIds.push(subnet.subnetId);
     }
+
+    const elastiCacheServlerless = new ElastiCache.CfnServerlessCache(this, "ServerlessCache", {
+      engine: "redis",
+      serverlessCacheName: props.elasticacheName.toLowerCase(),
+      cacheUsageLimits: {
+        dataStorage: {
+          unit: "GB",
+
+          maximum: props.storageMax,
+          minimum: props.storageMin,
+        },
+        ecpuPerSecond: {
+          maximum: props.maxEcpuPerSecond,
+          minimum: props.minEcpuPerSecond,
+        },
+      },
+      kmsKeyId: props.redisKmsKeyId,
+      majorEngineVersion: props.redisMajorVersion,
+      securityGroupIds: [ props.securityGroupId ],
+      subnetIds: elastiCacheSubnetIds,
+      userGroupId: `${props.elasticacheName}-userGroupId`.toLowerCase(),
+    });
+
+    elastiCacheServlerless.node.addDependency(cfnUserGroup)
+
+    this.endpointAddress = elastiCacheServlerless.attrEndpointAddress
+    this.endpointPort = elastiCacheServlerless.attrEndpointPort
+  }
 }


### PR DESCRIPTION
This PR introduces following changes:

1.  Datasources connection info is provided via code without hardcoded values in dev.json
2. aurora serverless route53 cname record is removed as the db hostname is used in cdk☝️ 