### PR TITLE
Fix session handling to use redis

### DIFF
--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -74,7 +74,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-250",
+            "image_tag": "ga-267",
             "allow_ecs_exec": true,
             "env_vars": {
                 "PID_SERVICE_URL": "http://localhost",
@@ -98,9 +98,10 @@
                 "SESSION_COOKIE_DOMAIN":".aoe.fi",
                 "SESSION_COOKIE_HTTP_ONLY": "true",
                 "SESSION_COOKIE_MAX_AGE": "86400000",
-                "SESSION_COOKIE_PATH": "/api",
+                "SESSION_COOKIE_PATH": "/",
                 "SESSION_COOKIE_SAME_SITE": "lax",
                 "SESSION_COOKIE_SECURE": "true",
+
                 "SESSION_OPTION_PROXY": "true",
                 "SESSION_OPTION_RESAVE": "false",
                 "SESSION_OPTION_ROLLING": "false",

--- a/aoe-infra/environments/qa.json
+++ b/aoe-infra/environments/qa.json
@@ -74,7 +74,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-250",
+            "image_tag": "ga-267",
             "allow_ecs_exec": true,
             "env_vars": {
                 "PID_SERVICE_URL": "http://localhost",
@@ -98,9 +98,10 @@
                 "SESSION_COOKIE_DOMAIN":".aoe.fi",
                 "SESSION_COOKIE_HTTP_ONLY": "true",
                 "SESSION_COOKIE_MAX_AGE": "86400000",
-                "SESSION_COOKIE_PATH": "/api",
+                "SESSION_COOKIE_PATH": "/",
                 "SESSION_COOKIE_SAME_SITE": "lax",
                 "SESSION_COOKIE_SECURE": "true",
+
                 "SESSION_OPTION_PROXY": "true",
                 "SESSION_OPTION_RESAVE": "false",
                 "SESSION_OPTION_ROLLING": "false",

--- a/aoe-web-backend/src/resource/redisClient.ts
+++ b/aoe-web-backend/src/resource/redisClient.ts
@@ -4,6 +4,7 @@ import winstonLogger from '@util/winstonLogger';
 import { createClient } from 'redis';
 
 const redisClient = createClient({
+  legacyMode: true,
   url: `${config.REDIS_OPTIONS.protocol}://${config.REDIS_OPTIONS.username}:${encodeURIComponent(
     config.REDIS_OPTIONS.pass,
   )}@${config.REDIS_OPTIONS.host}:${config.REDIS_OPTIONS.port}`,


### PR DESCRIPTION
This PR removes the in memory store that was used for express sessions.

The web-backend application uses only session with redis store so front end sessions still work after backend is redeployed as the session data is persisted into redis