### PR TITLE
Delay code for 2 seconds after index deletion

### DIFF
--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -81,7 +81,6 @@
                 "NODE_ENV": "production",
                 "LOG_LEVEL": "error",
                 "PORT_LISTEN": "8080",
-                "TEST_RUN": "false",
                 "MATERIAL_VERSION_URL": "https://dev.aoe.fi/#/materiaali/",
                 "HTTP_OPTIONS_TIMEOUT": "5000",
                 "HTTP_OPTIONS_RETRY": "2",

--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -74,7 +74,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-230",
+            "image_tag": "ga-242",
             "allow_ecs_exec": true,
             "env_vars": {
                 "PID_SERVICE_URL": "http://localhost",

--- a/aoe-web-backend/.env
+++ b/aoe-web-backend/.env
@@ -7,8 +7,6 @@ PORT=3000
 
 NODE_TLS_REJECT_UNAUTHORIZED=0
 
-TEST_RUN=true
-
 ## AOE server and service component general purpose configurations
 SERVER_CONFIG_OAIPMH_ANALYTICS_URL=http://aoe-data-analytics:8080
 

--- a/aoe-web-backend/src/config/index.ts
+++ b/aoe-web-backend/src/config/index.ts
@@ -7,7 +7,6 @@ const missingEnvs: string[] = [];
 process.env.NODE_ENV || missingEnvs.push('NODE_ENV');
 process.env.PORT_LISTEN || missingEnvs.push('PORT_LISTEN');
 process.env.LOG_LEVEL || missingEnvs.push('LOG_LEVEL');
-process.env.TEST_RUN || missingEnvs.push('TEST_RUN');
 process.env.CLOUD_STORAGE_ENABLED || missingEnvs.push('CLOUD_STORAGE_ENABLED');
 process.env.CLOUD_STORAGE_REGION || missingEnvs.push('CLOUD_STORAGE_REGION');
 process.env.CLOUD_STORAGE_BUCKET || missingEnvs.push('CLOUD_STORAGE_BUCKET');
@@ -48,14 +47,8 @@ process.env.STREAM_STATUS_PATH || missingEnvs.push('STREAM_STATUS_PATH');
 process.env.STREAM_STATUS_HOST_HTTPS_ENABLED || missingEnvs.push('STREAM_STATUS_HOST_HTTPS_ENABLED');
 process.env.PID_API_KEY || missingEnvs.push('PID_API_KEY');
 process.env.PID_SERVICE_URL || missingEnvs.push('PID_SERVICE_URL');
-
-if (process.env.TEST_RUN === 'true') {
-  process.env.PG_USER || missingEnvs.push('POSTGRES_USER');
-  process.env.PG_PASS || missingEnvs.push('POSTGRES_PASSWORD');
-} else {
-  process.env.PG_USER || missingEnvs.push('POSTGRES_USER_SECONDARY');
-  process.env.PG_PASS || missingEnvs.push('POSTGRES_PASSWORD_SECONDARY');
-}
+process.env.PG_USER || missingEnvs.push('PG_USER');
+process.env.PG_PASS || missingEnvs.push('PG_PASS');
 
 if (missingEnvs.length > 0) {
   winstonLogger.error('All required environment variables are not available: %s', missingEnvs);
@@ -69,7 +62,6 @@ export default {
     logLevel: process.env.LOG_LEVEL as string,
     nodeEnv: process.env.NODE_ENV as string,
     portListen: parseInt(process.env.PORT_LISTEN as string, 10) as number,
-    testRun: ((process.env.TEST_RUN as string).toLowerCase() === 'true') as boolean,
   } as const,
 
   // Cloud storage configurations.

--- a/aoe-web-backend/src/search/es.ts
+++ b/aoe-web-backend/src/search/es.ts
@@ -106,6 +106,9 @@ export const deleteIndex = async (index: string): Promise<boolean> => {
       return false;
     }
 
+    // delay added due to opensearch serverless issue with old index still being used for bulk
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
     for (let attempt = 0; attempt < 5; attempt++) {
       const exists = await indexExists(index);
       if (!exists) {


### PR DESCRIPTION
This Pr introduces two changes

1. Delay the code for 2 seconds after opensearch index is deleted. 
This is done to avoid unnecessary errors when making bulk copy. The problem is that after deletion of index and creation of new the web-backend tries to make a bulk copy to index. Sometimes it has been seen that the bulk copy targets the old just deleted index and fails either to missing index or succeeds to update the old index data.

The code already has checks that index is deleted and new index can be accessed but all of these seem to be not 100% working with AWS OpenSearch Serverless.

2. Remove not used TEST_RUN property

