### PR TITLE
Add possibility to just reload the data to index instead of index del…

### DIFF
--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -74,7 +74,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-244",
+            "image_tag": "ga-250",
             "allow_ecs_exec": true,
             "env_vars": {
                 "PID_SERVICE_URL": "http://localhost",


### PR DESCRIPTION
This PR introduces change to boot of web-backed opensearch index handling

1. If the CREATE_ES_INDEX flag is 1 old behaviour is executed. Delete -> create -> add mapping -> load data
2. If the CREATE_ES_INDEX flag is 0 only data is loaded/updated again (without deleting the old data)

The perfect solution would be to delete old documents first but this can be slow operation and could cause issues in production because the search is crucial for AOE
