### PR TITLE
Enable temp. domain for prod and QA deploy changes

### DIFF
--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -1,0 +1,56 @@
+name: Deploy QA
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to deploy
+        required: true
+      proceedDeploy:
+        description: Set to true to skip CDK diff and directly proceed with deployment. Default is false.
+        required: true
+        default: 'false'
+
+concurrency: deploy-qa
+
+env:
+  DOCKER_BUILDKIT: '1'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy_qa:
+    name: 05-deploy-qa.sh
+    permissions:
+      packages: read
+      id-token: write
+      contents: write
+    runs-on: 'ubuntu-24.04'
+    steps:
+      - uses: actions/checkout@v4.2.1
+      - name: Checkout all branches and tags with full history
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+      - name: Configure qa AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_AOE_QA_ROLE_ARN }}
+          role-session-name: aoe-runner-deploy-qa
+          aws-region: eu-west-1
+
+      - name: Run CDK Diff
+        if: ${{ github.event.inputs.proceedDeploy == 'false' }}
+        run: ./deploy-scripts/05-deploy-qa.sh diff
+        env:
+          UTILITY_ACCOUNT_ID: ${{ secrets.UTILITY_ACCOUNT_ID }}
+
+      - name: Run CDK Deploy
+        if: ${{ github.event.inputs.proceedDeploy == 'true' }}
+        run: ./deploy-scripts/05-deploy-qa.sh deploy
+        env:
+          UTILITY_ACCOUNT_ID: ${{ secrets.UTILITY_ACCOUNT_ID }}
+

--- a/aoe-infra/bin/infra.ts
+++ b/aoe-infra/bin/infra.ts
@@ -61,6 +61,9 @@ if (environmentName === 'utility') {
 
 // dev, qa & prod account resources..
 if (environmentName === 'dev' || environmentName === 'qa' || environmentName === 'prod') {
+
+  const domain = environmentName  === 'prod' ? `temp.${environmentConfig.aws.domain}` : environmentConfig.aws.domain
+
   new GithubActionsStack(app, 'GithubActionsStack', {
     environment: environmentName
   })
@@ -163,14 +166,14 @@ if (environmentName === 'dev' || environmentName === 'qa' || environmentName ===
     stackName: `${environmentName}-alb`,
     vpc: Network.vpc,
     securityGroupId: SecurityGroups.albSecurityGroup.securityGroupId,
-    domain: environmentConfig.aws.domain,
+    domain: domain,
     publicHostedZone: HostedZones.publicHostedZone
   })
 
   const CloudfrontCertificate = new CloudFrontCertificateStack(app, 'CloudFrontCertificateStack', {
     env: { region: 'us-east-1' },
     stackName: `${environmentName}-cloudfront-certificate`,
-    domain: environmentConfig.aws.domain,
+    domain: domain,
     hostedZone: HostedZones.publicHostedZone,
     crossRegionReferences: true
   })
@@ -179,7 +182,7 @@ if (environmentName === 'dev' || environmentName === 'qa' || environmentName ===
     env: { region: 'eu-west-1' },
     stackName: `${environmentName}-cloudfront`,
     alb: Alb.alb,
-    domain: environmentConfig.aws.domain,
+    domain: domain,
     publicHostedZone: HostedZones.publicHostedZone,
     certificate: CloudfrontCertificate.certificate,
     crossRegionReferences: true

--- a/aoe-infra/bin/infra.ts
+++ b/aoe-infra/bin/infra.ts
@@ -65,6 +65,7 @@ if (environmentName === 'dev' || environmentName === 'qa' || environmentName ===
   const domain = environmentName  === 'prod' ? `temp.${environmentConfig.aws.domain}` : environmentConfig.aws.domain
 
   new GithubActionsStack(app, 'GithubActionsStack', {
+    env: { region: 'eu-west-1' },
     environment: environmentName
   })
 

--- a/aoe-infra/environments/qa.json
+++ b/aoe-infra/environments/qa.json
@@ -10,7 +10,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-105",
+            "image_tag": "ga-205",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOGGING_LEVEL_FI_CSC": "ERROR",
@@ -51,7 +51,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-105",
+            "image_tag": "ga-205",
             "allow_ecs_exec": true,
             "env_vars": {
                 "SPRING_PROFILES_ACTIVE": "prod",
@@ -66,7 +66,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-172-qa",
+            "image_tag": "ga-257-qa",
             "allow_ecs_exec": true
         },
         "web_backend": {
@@ -74,14 +74,13 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-105",
+            "image_tag": "ga-250",
             "allow_ecs_exec": true,
             "env_vars": {
                 "PID_SERVICE_URL": "http://localhost",
                 "NODE_ENV": "production",
                 "LOG_LEVEL": "error",
                 "PORT_LISTEN": "8080",
-                "TEST_RUN": "false",
                 "MATERIAL_VERSION_URL": "https://qa.aoe.fi/#/materiaali/",
                 "HTTP_OPTIONS_TIMEOUT": "5000",
                 "HTTP_OPTIONS_RETRY": "2",
@@ -89,7 +88,7 @@
 
                 "POSTGRESQL_DATA": "aoe",
                 "PG_USER": "aoe_admin",
-                "SERVER_CONFIG_OAIPMH_ANALYTICS_URL": "https://qa.aoe.fi:8080/oaipmh",
+                "SERVER_CONFIG_OAIPMH_ANALYTICS_URL": "http://data-analytics.qa.aoe.local:8080",
                 "KAFKA_EXCLUDED_AGENT_IDENTIFIERS": "oersi",
                 "KAFKA_BROKER_TOPIC_MATERIAL_ACTIVITY": "prod_material_activity",
                 "KAFKA_BROKER_TOPIC_SEARCH_REQUESTS": "prod_search_requests",
@@ -128,16 +127,16 @@
                 "ES_SIZE_DEFAULT": "1000",
                 "ES_FROM_DEFAULT": "0",
 
-                "HTML_BASE_URL": "https://lessons.qa.aoe.fi",
+                "HTML_BASE_URL": "https://qa.aoe.fi",
                 "HTML_FOLDER": "/mnt/data/webdata/htmlfolder",
 
                 "H5P_JSON_CONFIGURATION": "dist/services/config/h5p.json",
                 "H5P_PATH_LIBRARIES": "/mnt/data/webdata/h5p/libraries",
                 "H5P_PATH_TEMPORARY_STORAGE": "/mnt/data/webdata/h5p/temporary-storage",
                 "H5P_PATH_CONTENT": "/mnt/data/webdata/h5p/content",
-                "H5P_PATH_CORE": "/mnt/data/webdata/h5p/core",
+                "H5P_PATH_CORE": "/app/h5p",
                 "H5P_PATH_EDITOR": "/mnt/data/webdata/h5p/editor",
-                "H5P_PLAY_API": "https://lessons.qa.aoe.fi/h5p/play/",
+                "H5P_PLAY_API": "https://qa.aoe.fi/h5p/play/",
                 "H5P_USER_EMAIL": "oppimateriaalivaranto@aoe.fi",
 
                 "MATERIAL_FILE_UPLOAD_FOLDER": "/mnt/data/uploads",
@@ -166,11 +165,13 @@
                 "PID_SERVICE_RUN_SCHEDULED": "0",
                 "PID_SERVICE_ENABLED": "0",
 
-                "STREAM_ENABLED": "0",
+                "STREAM_ENABLED": "1",
                 "STREAM_FILESIZE_MIN": "100000",
-                "STREAM_REDIRECT_URI": "https://stream.qa.aoe.fi/api/v1/material/",
-                "STREAM_STATUS_HOST": "streaming-app.qa.aoe.local:8080",
-                "STREAM_STATUS_PATH": "/api/v1/material/"
+                "STREAM_REDIRECT_URI": "https://qa.aoe.fi/stream/api/v1/material/",
+                "STREAM_STATUS_HOST": "streaming-app.qa.aoe.local",
+                "STREAM_STATUS_PORT": "8080",
+                "STREAM_STATUS_PATH": "/stream/api/v1/material/",
+                "STREAM_STATUS_HOST_HTTPS_ENABLED": "0"
             }
         },
         "streaming": {
@@ -178,7 +179,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-105",
+            "image_tag": "ga-205",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOG_LEVEL": "error",
@@ -194,10 +195,11 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-105",
+            "image_tag": "ga-205",
             "allow_ecs_exec": true,
             "env_vars": {
-                "LOG_LEVEL": "debug",
+                "NODE_ENV": "production",
+                "LOG_LEVEL": "error",
                 "PORT_LISTEN": "8080",
                 "REDIS_USERNAME": "app",
                 "REDIS_EXPIRE_TIME": "86400",
@@ -209,7 +211,7 @@
                 "EXTERNAL_API_SUOMI_KOODISTOT": "https://koodistot.suomi.fi/codelist-api/api/v1/coderegistries",
                 "EXTERNAL_API_OPINTOPOLKU_ORGANISAATIOT": "https://virkailija.opintopolku.fi/organisaatio-service/rest",
                 "EXTERNAL_API_OPINTOPOLKU_EPERUSTEET": "https://virkailija.opintopolku.fi/eperusteet-service/api"
-            }
+              }
         }
     },
     "msk": {
@@ -231,13 +233,13 @@
             "min_size_acu": 0.5,
             "max_size_acu": 1,
             "performance_insights": false
-        },
-        "web_backend": {
+          },
+          "web_backend": {
             "version": "16.4",
             "min_size_acu": 0.5,
             "max_size_acu": 1,
             "performance_insights": false
-        }
+          }
     },
     "document_db": {
         "engineVersion": "4.0.0"
@@ -254,6 +256,6 @@
             "storage_max": 5,
             "min_ecpu_per_second": 1000,
             "max_ecpu_per_second": 40000
-        }
+          }
     }
 }


### PR DESCRIPTION
This PR introduces temp. domain for prod ALB & CloudFront.
This is needed to be able to access the AWS AOE production before going live. 

Also QA deploy workflow  is added