### PR TITLE
Add SES to send emails from web-backend

### DIFF
--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -74,7 +74,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-281",
+            "image_tag": "ga-299",
             "allow_ecs_exec": true,
             "env_vars": {
                 "NODE_ENV": "production",
@@ -151,11 +151,13 @@
                 "REDIS_USERNAME": "app",
                 "REDIS_USE_TLS": "true",
                 "BASE_URL": "https://dev.aoe.fi/api/v1/",
-                "EMAIL_FROM": "oppimateriaalivaranto@aoe.fi",
-                "TRANSPORT_AUTH_USER": "oppimateriaalivaranto@aoe.fi",
-                "TRANSPORT_AUTH_HOST": "XXXX",
-                "TRANSPORT_PORT": "25",
-                "SEND_EMAIL": "0",
+                "EMAIL_FROM": "oppimateriaalivaranto@dev.aoe.fi",
+
+                "SEND_SYSTEM_NOTIFICATION_EMAIL" : "0",
+                "SEND_EXPIRATION_NOTIFICATION_EMAIL" : "0",
+                "SEND_RATING_NOTIFICATION:EMAIL": "0",
+                "SEND_VERIFICATION_EMAIL": "1",
+
                 "VERIFY_EMAIL_REDIRECT_URL": "/",
 
                 "CLOUD_STORAGE_ENABLED": "1",

--- a/aoe-infra/environments/prod.json
+++ b/aoe-infra/environments/prod.json
@@ -74,7 +74,7 @@
             "memory_limit": "4096",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-281",
+            "image_tag": "ga-299",
             "allow_ecs_exec": true,
             "env_vars": {
                 "NODE_ENV": "production",
@@ -151,11 +151,12 @@
                 "REDIS_USERNAME": "app",
                 "REDIS_USE_TLS": "true",
                 "BASE_URL": "https://aws.aoe.fi/api/v1/",
+
                 "EMAIL_FROM": "oppimateriaalivaranto@aoe.fi",
-                "TRANSPORT_AUTH_USER": "oppimateriaalivaranto@aoe.fi",
-                "TRANSPORT_AUTH_HOST": "XXXX",
-                "TRANSPORT_PORT": "25",
-                "SEND_EMAIL": "0",
+                "SEND_SYSTEM_NOTIFICATION_EMAIL" : "0",
+                "SEND_EXPIRATION_NOTIFICATION_EMAIL" : "0",
+                "SEND_RATING_NOTIFICATION:EMAIL": "0",
+                "SEND_VERIFICATION_EMAIL": "0",
                 "VERIFY_EMAIL_REDIRECT_URL": "/",
 
                 "CLOUD_STORAGE_ENABLED": "1",

--- a/aoe-infra/environments/qa.json
+++ b/aoe-infra/environments/qa.json
@@ -74,7 +74,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-281",
+            "image_tag": "ga-299",
             "allow_ecs_exec": true,
             "env_vars": {
                 "NODE_ENV": "production",
@@ -151,11 +151,12 @@
                 "REDIS_USERNAME": "app",
                 "REDIS_USE_TLS": "true",
                 "BASE_URL": "https://qa.aoe.fi/api/v1/",
-                "EMAIL_FROM": "oppimateriaalivaranto@aoe.fi",
-                "TRANSPORT_AUTH_USER": "oppimateriaalivaranto@aoe.fi",
-                "TRANSPORT_AUTH_HOST": "XXXX",
-                "TRANSPORT_PORT": "25",
-                "SEND_EMAIL": "0",
+
+                "EMAIL_FROM": "oppimateriaalivaranto@qa.aoe.fi",
+                "SEND_SYSTEM_NOTIFICATION_EMAIL" : "0",
+                "SEND_EXPIRATION_NOTIFICATION_EMAIL" : "0",
+                "SEND_RATING_NOTIFICATION:EMAIL": "0",
+                "SEND_VERIFICATION_EMAIL": "1",
                 "VERIFY_EMAIL_REDIRECT_URL": "/",
 
                 "CLOUD_STORAGE_ENABLED": "1",

--- a/aoe-infra/lib/secrets-manager-stack.ts
+++ b/aoe-infra/lib/secrets-manager-stack.ts
@@ -36,6 +36,7 @@ export class SecretManagerStack extends cdk.Stack {
         ANALYTICS_PG_PASS: {envVarName: 'SPRING_DATASOURCE_PRIMARY_PASSWORD', path: '/auroradbs/web-backend/dev/reporter', secretKey: 'password' },
         ANALYTICS_DOCDB_PASSWORD: {envVarName: 'MONGODB_PRIMARY_PASSWORD', path: '/service/data-analytics/DOCDB_PASS', secretKey: 'secretkey' },
         ANALYTICS_TRUST_STORE_PASSWORD: {envVarName: 'TRUST_STORE_PASS', path: '/service/data-analytics/TRUST_STORE_PASS', secretKey: 'secretkey' },
+        ADMIN_EMAIL: {envVarName: 'ADMIN_EMAIL', path: '/service/web-backend/ADMIN_EMAIL', secretKey: 'secretkey' },
     }
 
     constructor(scope: Construct, id: string, props: SecretManagerStackProps) {

--- a/aoe-infra/lib/ses-stack.ts
+++ b/aoe-infra/lib/ses-stack.ts
@@ -1,0 +1,26 @@
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ses from 'aws-cdk-lib/aws-ses'
+import { HostedZone } from 'aws-cdk-lib/aws-route53';
+import * as cdk from 'aws-cdk-lib';
+import { EmailIdentity } from "aws-cdk-lib/aws-ses";
+
+interface sesProps extends StackProps {
+  hostedZone: HostedZone
+}
+
+export class SesStack extends Stack {
+  public emailIdentity: EmailIdentity;
+
+  constructor(scope: Construct, id: string, props: sesProps) {
+    super(scope, id, props);
+    this.emailIdentity = new ses.EmailIdentity(this, 'EmailIdentity', {
+      identity: ses.Identity.publicHostedZone(props.hostedZone)
+    })
+
+    new cdk.CfnOutput(this, 'EmailIdentityArn', {
+      value: this.emailIdentity.emailIdentityArn,
+      description: 'The ARN of the SES Email Identity',
+    });
+  }
+}


### PR DESCRIPTION
This PR introduces AWS SES to dev and QA environments with domain identity.

aoe-web-backend mailService has been changed to use AWS SDK V2 SES to send emails instead of node mailer. 

After deployment the SES is in sandbox mode which means that only to verified emails aoe can send an email. For production we need to request production access once the SES is deployed.