### PR TITLE
Do not delete opensearch index during boot up

### DIFF
--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -119,7 +119,7 @@
                 "SUCCESS_REDIRECT_URI": "/",
                 "FAILURE_REDIRECT_URI": "/api/login",
 
-                "CREATE_ES_INDEX": "1",
+                "CREATE_ES_INDEX": "0",
                 "ES_INDEX": "aoe",
                 "ES_MAPPING_FILE": "/app/aoemapping.json",
                 "ES_COLLECTION_INDEX": "aoecollection",

--- a/aoe-infra/environments/prod.json
+++ b/aoe-infra/environments/prod.json
@@ -119,7 +119,7 @@
                 "SUCCESS_REDIRECT_URI": "/",
                 "FAILURE_REDIRECT_URI": "/api/login",
 
-                "CREATE_ES_INDEX": "1",
+                "CREATE_ES_INDEX": "0",
                 "ES_INDEX": "aoe",
                 "ES_MAPPING_FILE": "/app/aoemapping.json",
                 "ES_COLLECTION_INDEX": "aoecollection",

--- a/aoe-infra/environments/qa.json
+++ b/aoe-infra/environments/qa.json
@@ -119,7 +119,7 @@
                 "SUCCESS_REDIRECT_URI": "/",
                 "FAILURE_REDIRECT_URI": "/api/login",
 
-                "CREATE_ES_INDEX": "1",
+                "CREATE_ES_INDEX": "0",
                 "ES_INDEX": "aoe",
                 "ES_MAPPING_FILE": "/app/aoemapping.json",
                 "ES_COLLECTION_INDEX": "aoecollection",


### PR DESCRIPTION
This PR disables the OpenSearch index deletion during boot of aoe-web-backend.

The service will create the index before loading the data if it does not exist. 