### PR TITLE
Add backup rds and documentdb backup retention

### DIFF
--- a/aoe-infra/bin/infra.ts
+++ b/aoe-infra/bin/infra.ts
@@ -247,6 +247,7 @@ if (environmentName === 'dev' || environmentName === 'qa' || environmentName ===
   })
 
   const docDb = new DocumentdbStack(app, 'AOEDocumentDB', {
+    environment : environmentName,
     instances: environmentConfig.document_db.instances,
     instanceType: environmentConfig.document_db.instanceType,
     env: { region: 'eu-west-1' },

--- a/aoe-infra/lib/aurora-serverless-database.ts
+++ b/aoe-infra/lib/aurora-serverless-database.ts
@@ -4,6 +4,7 @@ import { AuroraPostgresEngineVersion, DatabaseCluster, DatabaseClusterEngine, Cl
 import { IVpc, ISecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import * as cdk from 'aws-cdk-lib'
 
 interface AuroraDatabaseProps extends StackProps {
   environment: string;
@@ -69,6 +70,9 @@ export class AuroraDatabaseStack extends Stack {
       deletionProtection: true,
       securityGroups: [props.securityGroup],
       subnetGroup: props.subnetGroup,
+      backup: {
+        retention : props.environment === 'prod' ? cdk.Duration.days(30) : cdk.Duration.days(7)
+      },
       credentials: {
         username: 'aoe_db_admin',
         password: props.auroraDbPassword.secretValueFromJson('password')

--- a/aoe-infra/lib/documentdb-stack.ts
+++ b/aoe-infra/lib/documentdb-stack.ts
@@ -6,6 +6,7 @@ import { Secret } from "aws-cdk-lib/aws-secretsmanager";
 import { Key } from "aws-cdk-lib/aws-kms";
 
 interface DocumentDbStackProps extends cdk.StackProps {
+  environment: string;
   instances: number;
   engineVersion: string;
   vpc: IVpc;
@@ -33,7 +34,10 @@ export class DocumentdbStack extends cdk.Stack {
       vpcSubnets: {subnets: props.vpc.isolatedSubnets },
       securityGroup: props.securityGroup,
       deletionProtection: true,
-      kmsKey: props.kmsKey
+      kmsKey: props.kmsKey,
+      backup : {
+        retention : props.environment === 'prod' ? cdk.Duration.days(30) : cdk.Duration.days(7)
+      }
     })
 
     this.clusterEndpoint = this.docdbcluster.clusterEndpoint


### PR DESCRIPTION
This PR adds backup retention to RDS Aurora and DocumentDB

Dev and qa envs the backup retention is seven days and for production 30 days