### PR TITLE
Change opensearch fuzziness to 1 instead of AUTO

### DIFF
--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -74,7 +74,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-319",
+            "image_tag": "ga-364",
             "allow_ecs_exec": true,
             "env_vars": {
                 "NODE_ENV": "production",

--- a/aoe-infra/environments/prod.json
+++ b/aoe-infra/environments/prod.json
@@ -74,7 +74,7 @@
             "memory_limit": "4096",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-319",
+            "image_tag": "ga-364",
             "allow_ecs_exec": true,
             "env_vars": {
                 "NODE_ENV": "production",

--- a/aoe-infra/environments/qa.json
+++ b/aoe-infra/environments/qa.json
@@ -74,7 +74,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-319",
+            "image_tag": "ga-364",
             "allow_ecs_exec": true,
             "env_vars": {
                 "NODE_ENV": "production",

--- a/aoe-web-backend/src/search/esQueries.ts
+++ b/aoe-web-backend/src/search/esQueries.ts
@@ -303,7 +303,7 @@ export function createMultiMatchObject(keywords: string, fields: string[]) {
     'multi_match': {
       'query': keywords,
       'fields': fields,
-      'fuzziness': 'AUTO'
+      'fuzziness': '1'
     }
   };
 }


### PR DESCRIPTION
Due to performance issues change the fuzziness from auto to 1 to reduce query rewrite time.

With fuzziness AUTO opensearch query rewrite time was majority of the total search time.