### PR TITLE
Fix CDK env attribute

### DIFF
--- a/aoe-infra/bin/infra.ts
+++ b/aoe-infra/bin/infra.ts
@@ -41,8 +41,8 @@ const app = new cdk.App()
 // Load up configuration for the environment
 const environmentName: string = app.node.tryGetContext('environment')
 const utilityAccountId: string = app.node.tryGetContext('UTILITY_ACCOUNT_ID')
-const envEU = { account: process.env.CDK_DEFAULT_ACCOUNT, region: 'eu-west-1' }
-const envUS = { account: process.env.CDK_DEFAULT_ACCOUNT, region: 'us-east-1' }
+const envEU = { region: 'eu-west-1' }
+const envEUAccount = { account: process.env.CDK_DEFAULT_ACCOUNT, region: 'eu-west-1' }
 
 // Allow any in this case, since we don't want to explicitely type json data
 /* eslint-disable  @typescript-eslint/no-explicit-any */
@@ -74,7 +74,8 @@ if (environmentName === 'dev' || environmentName === 'qa' || environmentName ===
   })
 
   const Monitor = new MonitorStack(app, 'MonitorStack', {
-    env: envEU,
+    env: envEUAccount,
+
     slackChannelName: `valvonta-aoe-${environmentName}`,
     environment: environmentName,
   })
@@ -188,7 +189,7 @@ if (environmentName === 'dev' || environmentName === 'qa' || environmentName ===
   })
 
   const CloudfrontCertificate = new CloudFrontCertificateStack(app, 'CloudFrontCertificateStack', {
-    env: envUS,
+    env: { region: 'us-east-1' },
     stackName: `${environmentName}-cloudfront-certificate`,
     domain: domain,
     hostedZone: HostedZones.publicHostedZone,

--- a/aoe-infra/bin/infra.ts
+++ b/aoe-infra/bin/infra.ts
@@ -43,6 +43,7 @@ const environmentName: string = app.node.tryGetContext('environment')
 const utilityAccountId: string = app.node.tryGetContext('UTILITY_ACCOUNT_ID')
 const envEU = { region: 'eu-west-1' }
 const envEUAccount = { account: process.env.CDK_DEFAULT_ACCOUNT, region: 'eu-west-1' }
+const envUS = { region: 'us-east-1' }
 
 // Allow any in this case, since we don't want to explicitely type json data
 /* eslint-disable  @typescript-eslint/no-explicit-any */
@@ -189,7 +190,7 @@ if (environmentName === 'dev' || environmentName === 'qa' || environmentName ===
   })
 
   const CloudfrontCertificate = new CloudFrontCertificateStack(app, 'CloudFrontCertificateStack', {
-    env: { region: 'us-east-1' },
+    env: envUS,
     stackName: `${environmentName}-cloudfront-certificate`,
     domain: domain,
     hostedZone: HostedZones.publicHostedZone,

--- a/aoe-infra/lib/monitor-stack.ts
+++ b/aoe-infra/lib/monitor-stack.ts
@@ -21,7 +21,9 @@ export class MonitorStack extends cdk.Stack {
     const slackChannelId = ssm.StringParameter.valueFromLookup(this, '/monitor/slack_channel_id');
     const slackWorkspaceId = ssm.StringParameter.valueFromLookup(this, '/monitor/slack_workspace_id');
 
-    this.topic = new sns.Topic(this, `${props.environment}-cloudwatch-slack`);
+    this.topic = new sns.Topic(this, `${props.environment}-cloudwatch-slack`, {
+      topicName: `${props.environment}-cloudwatch-slack`,
+    });
 
     this.slackChannel = new chatbot.SlackChannelConfiguration(this, 'SlackChannel', {
       slackChannelConfigurationName: `${props.slackChannelName}`,


### PR DESCRIPTION
The adding of account to env caused VPC subnets to be recreated.

Revert back to previous env without account and also support new monitor stack.