### PR TITLE
WIP: Strip out all control characters in GeneralType XML output having values between 0x00-0x08

### DIFF
--- a/aoe-data-services/oaipmh-provider/src/main/java/fi/csc/provider/model/xml_lrmi/sublevel_1st/sublevel_2nd/GeneralType.java
+++ b/aoe-data-services/oaipmh-provider/src/main/java/fi/csc/provider/model/xml_lrmi/sublevel_1st/sublevel_2nd/GeneralType.java
@@ -3,11 +3,9 @@ package fi.csc.provider.model.xml_lrmi.sublevel_1st.sublevel_2nd;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlValue;
-import lombok.Getter;
 import lombok.Setter;
 
 @SuppressWarnings("unused")
-@Getter
 @Setter
 @XmlAccessorType(XmlAccessType.NONE)
 public class GeneralType {
@@ -15,4 +13,9 @@ public class GeneralType {
     @XmlValue
     private String value;
 
+    public String getValue() {
+        // Remove all ASCII low-end control characters from value on get, since
+        // they are not allowed in XML
+        return value.replaceAll("[\\x00-\\x08]", "");
+    }
 }

--- a/aoe-infra/environments/prod.json
+++ b/aoe-infra/environments/prod.json
@@ -10,7 +10,7 @@
             "memory_limit": "2048",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-422",
+            "image_tag": "ga-459",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOGGING_LEVEL_FI_CSC": "ERROR",
@@ -51,7 +51,7 @@
             "memory_limit": "4096",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-447",
+            "image_tag": "ga-459",
             "allow_ecs_exec": true,
             "env_vars": {
                 "SPRING_PROFILES_ACTIVE": "prod",


### PR DESCRIPTION
They are not allowed in XML at all, and can be accidentally copy-pasted into data.