### PR TITLE
Add sv, en and fi footer links

### DIFF
--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -66,7 +66,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-453-dev",
+            "image_tag": "ga-467-dev",
             "allow_ecs_exec": true
         },
         "web_backend": {

--- a/aoe-infra/environments/prod.json
+++ b/aoe-infra/environments/prod.json
@@ -66,7 +66,7 @@
             "memory_limit": "4096",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-453-prod",
+            "image_tag": "ga-467-prod",
             "allow_ecs_exec": true
         },
         "web_backend": {

--- a/aoe-infra/environments/qa.json
+++ b/aoe-infra/environments/qa.json
@@ -66,7 +66,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-453-qa",
+            "image_tag": "ga-467-qa",
             "allow_ecs_exec": true
         },
         "web_backend": {

--- a/aoe-web-frontend/src/app/containers/default-layout/default-layout.component.html
+++ b/aoe-web-frontend/src/app/containers/default-layout/default-layout.component.html
@@ -97,13 +97,15 @@
       <div class="col-sm-6 col-md">
         <ul class="nav flex-column">
           <li class="nav-item">
-            <a href="https://www.oph.fi/fi/node/17792">{{ "navigation.termsOfUse" | translate }}</a>
+            <a [href]="links.termsOfUsage[translate.currentLang].link">{{ "navigation.termsOfUse" | translate }}</a>
           </li>
           <li class="nav-item">
-            <a href="https://www.oph.fi/fi/node/17791">{{ "navigation.privacyPolicy" | translate }}</a>
+            <a [href]="links.privacyPolicy[translate.currentLang].link">{{ "navigation.privacyPolicy" | translate }}</a>
           </li>
           <li class="nav-item">
-            <a href="https://www.oph.fi/fi/node/17793">{{ "navigation.accessibilityPolicy" | translate }}</a>
+            <a [href]="links.accessibilityStatement[translate.currentLang].link">
+              {{ "navigation.accessibilityPolicy" | translate }}
+            </a>
           </li>
         </ul>
       </div>

--- a/aoe-web-frontend/src/app/containers/default-layout/default-layout.component.ts
+++ b/aoe-web-frontend/src/app/containers/default-layout/default-layout.component.ts
@@ -27,6 +27,42 @@ export class DefaultLayoutComponent implements OnInit {
   // window !== window.top : true => The site is in a frame.
   embedded: boolean = window !== window.top;
 
+  links = {
+    termsOfUsage: {
+      fi: {
+        link: 'https://www.oph.fi/fi/node/17792',
+      },
+      en: {
+        link: 'https://www.oph.fi/en/node/17792',
+      },
+      sv: {
+        link: 'https://www.oph.fi/sv/node/17792',
+      },
+    },
+    privacyPolicy: {
+      fi: {
+        link: 'https://www.oph.fi/fi/node/17791',
+      },
+      en: {
+        link: 'https://www.oph.fi/en/node/17791',
+      },
+      sv: {
+        link: 'https://www.oph.fi/sv/node/17791',
+      },
+    },
+    accessibilityStatement: {
+      fi: {
+        link: 'https://www.oph.fi/fi/node/17793',
+      },
+      en: {
+        link: 'https://www.oph.fi/en/node/17793',
+      },
+      sv: {
+        link: 'https://www.oph.fi/sv/node/17793',
+      },
+    },
+  };
+
   logos = {
     okm: {
       fi: {

--- a/aoe-web-frontend/src/app/mocks/faq.organisation.mock.ts
+++ b/aoe-web-frontend/src/app/mocks/faq.organisation.mock.ts
@@ -37,7 +37,7 @@ export const FAQOrganisation = {
     {
       question: 'What kind of metadata model does the Library of Open Educational Resources have?',
       answer: [
-        'The service uses an internationally compatible LRMI-based metadata model, which is intended to facilitate finding educational resources in a high-quality way. Over the course of the project, the metadata model was profiled to meet the needs of the Finnish education sector in collaboration with stakeholders. The model continues to be developed. Please see this <a href="https://wiki.eduuni.fi/x/tQBEDQ" target="_blank" rel="noopener nofollow">wikipage for up-to-date documentation on the model</a>. The metadata model and the vocabularies it utilizes are openly available for use.',
+        'The service uses an internationally compatible LRMI-based metadata model, which is intended to facilitate finding educational resources in a high-quality way. Over the course of the project, the metadata model was profiled to meet the needs of the Finnish education sector in collaboration with stakeholders. The model continues to be developed. Please see this <a href="https://wiki.eduuni.fi/x/tQBEDQ" target="_blank" rel="noopener nofollow">wikipage for up-to-date documentation on the model (in Finnish)</a>. The metadata model and the vocabularies it utilizes are openly available for use.',
       ],
     },
     {
@@ -58,7 +58,7 @@ export const FAQOrganisation = {
     {
       question: 'Hur ser metadatamodellen för Biblioteket för öppna lärresurser ut?',
       answer: [
-        'Biblioteket för öppna lärresurser använder en internationellt kompatibel, LRMI-baserad metadatamodell som är avsedd att göra det lättare att hitta högklassiga lärresurser. Under projektets gång utformades metadatamodellen tillsammans med intressentgrupperna för de behov som finns på det finländska utbildningsfältet. Metadatamodellen vidareutvecklas och den nyaste <a href="https://wiki.eduuni.fi/x/tQBEDQ" target="_blank" rel="noopener nofollow">dokumentationen om metadatamodellen finns på den här wikisidan</a>. Metadatamodellen och dess terminologier är öppet tillgängliga.',
+        'Biblioteket för öppna lärresurser använder en internationellt kompatibel, LRMI-baserad metadatamodell som är avsedd att göra det lättare att hitta högklassiga lärresurser. Under projektets gång utformades metadatamodellen tillsammans med intressentgrupperna för de behov som finns på det finländska utbildningsfältet. Metadatamodellen vidareutvecklas och den nyaste <a href="https://wiki.eduuni.fi/x/tQBEDQ" target="_blank" rel="noopener nofollow">dokumentationen om metadatamodellen finns på den här wikisidan (på finska)</a>. Metadatamodellen och dess terminologier är öppet tillgängliga.',
       ],
     },
     {


### PR DESCRIPTION
This PR adds English, Swedish and Finnish links to terms if usage, privacy policy and accessibility statement links and info page  text fixes 