### PR TITLE
Fix failing health check of data-analytics 

### DIFF
--- a/aoe-data-analytics/service-etl-processor/src/main/java/fi/csc/processor/ServiceEtlProcessorApplication.java
+++ b/aoe-data-analytics/service-etl-processor/src/main/java/fi/csc/processor/ServiceEtlProcessorApplication.java
@@ -5,8 +5,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.Banner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class ServiceEtlProcessorApplication {
 
     private static final Logger LOG = LoggerFactory.getLogger(ServiceEtlProcessorApplication.class.getSimpleName());

--- a/aoe-data-analytics/service-etl-processor/src/main/java/fi/csc/processor/controller/KafkaController.java
+++ b/aoe-data-analytics/service-etl-processor/src/main/java/fi/csc/processor/controller/KafkaController.java
@@ -7,14 +7,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.CompletableFuture;
-
-import static fi.csc.processor.utils.AsyncUtil.async;
 
 @RestController
 @RequestMapping(value = "/produce")
@@ -27,18 +26,20 @@ public class KafkaController {
     }
 
     @PostMapping(path = "/prod/materialactivity", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Async
     public CompletableFuture<ResponseEntity<Void>> sendMessageToKafkaTopicPrimary(
         @RequestBody MaterialActivity materialActivity) {
-        return async(() -> {
+        return CompletableFuture.supplyAsync(() -> {
             this.kafkaProducer.sendMaterialActivityPrimary(materialActivity);
             return new ResponseEntity<>(HttpStatus.ACCEPTED);
         });
     }
 
     @PostMapping(path = "/prod/searchrequests", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Async
     public CompletableFuture<ResponseEntity<Void>> sendMessageToKafkaTopicPrimary(
         @RequestBody SearchRequest searchRequest) {
-        return async(() -> {
+        return CompletableFuture.supplyAsync(() -> {
             this.kafkaProducer.sendSearchRequestsPrimary(searchRequest);
             return new ResponseEntity<>(HttpStatus.ACCEPTED);
         });

--- a/aoe-data-analytics/service-etl-processor/src/main/java/fi/csc/processor/controller/StatisticsController.java
+++ b/aoe-data-analytics/service-etl-processor/src/main/java/fi/csc/processor/controller/StatisticsController.java
@@ -16,11 +16,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.concurrent.CompletableFuture;
-
-import static fi.csc.processor.utils.AsyncUtil.async;
 
 @RestController
 @RequestMapping(value = "/statistics")
@@ -40,50 +39,55 @@ public class StatisticsController {
     @PostMapping(path = "/prod/educationallevel/all",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
+    @Async
     public CompletableFuture<ResponseEntity<StatisticsMeta<?>>> getEducationalLevelDistribution(
         @RequestBody EducationalLevelTotalRequest educationalLevelTotalRequest) {
-        return async(() -> new ResponseEntity<>(this.statisticsService.getEducationalLevelDistribution(
+        return CompletableFuture.supplyAsync(() -> new ResponseEntity<>(this.statisticsService.getEducationalLevelDistribution(
             educationalLevelTotalRequest), HttpStatus.OK));
     }
 
     @PostMapping(path = "/prod/educationallevel/expired",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
+    @Async
     public CompletableFuture<ResponseEntity<StatisticsMeta<?>>> getEducationalLevelExpired(
         @RequestBody EducationalLevelTotalRequest educationalLevelTotalRequest) {
         if (educationalLevelTotalRequest.getExpiredBefore() != null) {
-            return async(() -> new ResponseEntity<>(this.statisticsService.getEducationalLevelExpired(
+            return CompletableFuture.supplyAsync(() -> new ResponseEntity<>(this.statisticsService.getEducationalLevelExpired(
                 educationalLevelTotalRequest), HttpStatus.OK));
         } else {
-            return async(() -> new ResponseEntity<>(HttpStatus.BAD_REQUEST));
+            return CompletableFuture.supplyAsync(() -> new ResponseEntity<>(HttpStatus.BAD_REQUEST));
         }
     }
 
     @PostMapping(path = "/prod/educationalsubject/all",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
+    @Async
     public CompletableFuture<ResponseEntity<StatisticsMeta<?>>> getEducationalSubjectDistribution(
         @RequestBody EducationalSubjectTotalRequest educationalSubjectTotalRequest) {
-        return async(() -> new ResponseEntity<>(this.statisticsService.getEducationalSubjectDistribution(
+        return CompletableFuture.supplyAsync(() -> new ResponseEntity<>(this.statisticsService.getEducationalSubjectDistribution(
             educationalSubjectTotalRequest), HttpStatus.OK));
     }
 
     @PostMapping(path = "/prod/organization/all",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
+    @Async
     public CompletableFuture<ResponseEntity<StatisticsMeta<?>>> getOrganizationDistribution(
         @RequestBody OrganizationTotalRequest organizationTotalRequest) {
-        return async(() -> new ResponseEntity<>(this.statisticsService.getOrganizationDistribution(
+        return CompletableFuture.supplyAsync(() -> new ResponseEntity<>(this.statisticsService.getOrganizationDistribution(
             organizationTotalRequest), HttpStatus.OK));
     }
 
     @PostMapping(path = "/prod/materialactivity/{interval}/total",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
+    @Async
     public CompletableFuture<ResponseEntity<StatisticsMeta<?>>> getMaterialActivityTotalByInterval(
         @PathVariable(value = "interval") Interval interval,
         @RequestBody IntervalTotalRequest intervalTotalRequest) {
-        return async(() -> new ResponseEntity<>(this.timeSeriesService.getTotalByInterval(
+        return CompletableFuture.supplyAsync(() -> new ResponseEntity<>(this.timeSeriesService.getTotalByInterval(
             interval,
             intervalTotalRequest,
             MaterialActivityDocument.class), HttpStatus.OK));
@@ -92,10 +96,11 @@ public class StatisticsController {
     @PostMapping(path = "/prod/searchrequests/{interval}/total",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
+    @Async
     public CompletableFuture<ResponseEntity<StatisticsMeta<?>>> getSearchRequestsTotalByInterval(
         @PathVariable(value = "interval") Interval interval,
         @RequestBody IntervalTotalRequest intervalTotalRequest) {
-        return async(() -> new ResponseEntity<>(this.timeSeriesService.getTotalByInterval(
+        return CompletableFuture.supplyAsync(() -> new ResponseEntity<>(this.timeSeriesService.getTotalByInterval(
             interval,
             intervalTotalRequest,
             SearchRequestDocument.class), HttpStatus.OK));

--- a/aoe-data-analytics/service-etl-processor/src/main/java/fi/csc/processor/controller/StatusController.java
+++ b/aoe-data-analytics/service-etl-processor/src/main/java/fi/csc/processor/controller/StatusController.java
@@ -3,18 +3,18 @@ package fi.csc.processor.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.CompletableFuture;
 
-import static fi.csc.processor.utils.AsyncUtil.async;
-
 @RestController
 public class StatusController {
 
     @GetMapping(path = "/status", produces = MediaType.TEXT_PLAIN_VALUE)
+    @Async
     public CompletableFuture<ResponseEntity<String>> getStatus() {
-        return async(() -> new ResponseEntity<>("Service operable: true", HttpStatus.OK));
+        return CompletableFuture.supplyAsync(() -> new ResponseEntity<>("Service operable: true", HttpStatus.OK));
     }
 }

--- a/aoe-infra/bin/infra.ts
+++ b/aoe-infra/bin/infra.ts
@@ -363,7 +363,7 @@ if (environmentName === 'dev' || environmentName === 'qa' || environmentName ===
     utilityAccountId: utilityAccountId,
     alb: Alb.alb,
     listener: Alb.albListener,
-    listenerPathPatterns: ['/analytics/api/*'],
+    listenerPathPatterns: ['/analytics/api/status'],
     healthCheckPath: '/analytics/api/status',
     healthCheckGracePeriod: 180,
     healthCheckInterval: 5,

--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -10,7 +10,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-422",
+            "image_tag": "ga-500",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOGGING_LEVEL_FI_CSC": "ERROR",

--- a/aoe-infra/environments/prod.json
+++ b/aoe-infra/environments/prod.json
@@ -10,7 +10,7 @@
             "memory_limit": "2048",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-422",
+            "image_tag": "ga-500",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOGGING_LEVEL_FI_CSC": "ERROR",

--- a/aoe-infra/environments/qa.json
+++ b/aoe-infra/environments/qa.json
@@ -10,7 +10,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-422",
+            "image_tag": "ga-500",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOGGING_LEVEL_FI_CSC": "ERROR",


### PR DESCRIPTION
Analytics service health checks failed when there were long running rest requests. 

Added async annotation and also removed the public access to endpoints as the service is only used via web-backend