### PR TITLE
Handle response stream close event and abort S3 get request if it happens

### DIFF
--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -181,7 +181,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-507",
+            "image_tag": "ga-512",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOG_LEVEL": "error",

--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -181,7 +181,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-422",
+            "image_tag": "ga-507",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOG_LEVEL": "error",

--- a/aoe-infra/environments/prod.json
+++ b/aoe-infra/environments/prod.json
@@ -180,7 +180,7 @@
             "memory_limit": "4096",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-422",
+            "image_tag": "ga-512",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOG_LEVEL": "error",

--- a/aoe-infra/environments/qa.json
+++ b/aoe-infra/environments/qa.json
@@ -180,7 +180,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-422",
+            "image_tag": "ga-512",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOG_LEVEL": "error",

--- a/aoe-streaming-app/src/service/storage-service.ts
+++ b/aoe-streaming-app/src/service/storage-service.ts
@@ -75,8 +75,9 @@ export const getObjectAsStream = async (req: Request, res: Response): Promise<vo
       };
 
       // Request configuration and event handlers
-      const getRequest: AWS.Request<S3.GetObjectOutput, AWS.AWSError> = s3
-        .getObject(getRequestObject)
+      const getRequest: AWS.Request<S3.GetObjectOutput, AWS.AWSError> = s3.getObject(getRequestObject);
+
+      getRequest
         .on('error', (error: AWSError) => {
           winstonLogger.error('S3 GET request failed: %o', error);
         })
@@ -100,13 +101,17 @@ export const getObjectAsStream = async (req: Request, res: Response): Promise<vo
             res.status(status);
           }
         });
-      // Handle client closing connection prematurely
-      res.on('close', () => {
+
+      // Stream configuration and event handlers
+      const stream = getRequest.createReadStream();
+
+      req.on('close', () => {
+        winstonLogger.debug('Request closed');
+        stream.destroy();
         getRequest.abort();
       });
-      // Stream configuration and event handlers
-      getRequest
-        .createReadStream()
+
+      stream
         .once('error', (error: AWSError) => {
           if (error.name === 'NoSuchKey') {
             winstonLogger.debug('Requested file %s not found', fileName);
@@ -121,6 +126,10 @@ export const getObjectAsStream = async (req: Request, res: Response): Promise<vo
             res.status(error.statusCode || 500);
             reject(error);
           }
+        })
+        .once('close', () => {
+          winstonLogger.debug('S3 read stream closed');
+          resolve();
         })
         .once('end', () => {
           winstonLogger.debug(

--- a/aoe-streaming-app/src/service/storage-service.ts
+++ b/aoe-streaming-app/src/service/storage-service.ts
@@ -100,6 +100,10 @@ export const getObjectAsStream = async (req: Request, res: Response): Promise<vo
             res.status(status);
           }
         });
+      // Handle client closing connection prematurely
+      res.on('close', () => {
+        getRequest.abort();
+      });
       // Stream configuration and event handlers
       getRequest
         .createReadStream()


### PR DESCRIPTION
```close``` event should only happen if client closes connection prematurely, but this needs verification.