### PR TITLE
Suppress unneeded RequestAbortedError from error logs

### DIFF
--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -181,7 +181,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-512",
+            "image_tag": "ga-514",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOG_LEVEL": "error",

--- a/aoe-infra/environments/dev.json
+++ b/aoe-infra/environments/dev.json
@@ -181,7 +181,7 @@
             "memory_limit": "1024",
             "min_count": 1,
             "max_count": 1,
-            "image_tag": "ga-514",
+            "image_tag": "ga-515",
             "allow_ecs_exec": true,
             "env_vars": {
                 "LOG_LEVEL": "error",

--- a/aoe-streaming-app/src/service/storage-service.ts
+++ b/aoe-streaming-app/src/service/storage-service.ts
@@ -79,7 +79,9 @@ export const getObjectAsStream = async (req: Request, res: Response): Promise<vo
 
       getRequest
         .on('error', (error: AWSError) => {
-          winstonLogger.error('S3 GET request failed: %o', error);
+          if (error.name !== 'RequestAbortedError') {
+            winstonLogger.error('S3 GET request failed: %o', error);
+          }
         })
         .on('httpHeaders', (status: number, headers: { [p: string]: string }) => {
           // Forward headers to the response


### PR DESCRIPTION
`RequestAbortedError` happens if user navigates out from page and outgoing response stream get closed, so it should be safe to ignore.

There is also a `TimeoutError` if the client fails to download the chunk in time, which may or may not be a real error.